### PR TITLE
renaming PreImagesRepresentative to NC version

### DIFF
--- a/doc/funcs.xml
+++ b/doc/funcs.xml
@@ -206,13 +206,13 @@ gap> hom := GroupHomomorphismByImages( g, u,
 >             GeneratorsOfGroup(u) );
 [ a, b ] -> [ f1^2*f2^2, f1^2*f2 ]
 gap> # how can f.1^2 be expressed?
-gap> PreImagesRepresentative( hom, f.1^2 );
+gap> PreImagesRepresentativeNC( hom, f.1^2 );
 b*a^-1*b
 gap> last ^ hom; # check this
 f1^2
 gap> ub * ua^-1 * ub; # another check
 f1^2
-gap> PreImagesRepresentative( hom, f.1 ); # try f.1
+gap> PreImagesRepresentativeNC( hom, f.1 ); # try f.1
 fail
 gap> f.1 in u;
 false

--- a/init.g
+++ b/init.g
@@ -7,6 +7,11 @@
 #Y 2003 - 2012
 ##
 
+##  introducing globally the NC version of PreImagesRepresentative 
+if not IsBound( PreImagesRepresentativeNC ) then 
+    BindGlobal( "PreImagesRepresentativeNC", PreImagesRepresentative ); 
+fi; 
+
 ReadPackage( "FGA", "lib/util.gd" );
 ReadPackage( "FGA", "lib/Iterated.gd" );
 ReadPackage( "FGA", "lib/Autom.gd" );

--- a/lib/Hom.gi
+++ b/lib/Hom.gi
@@ -8,7 +8,7 @@
 ##
 
 
-InstallMethod( PreImagesRepresentative,
+InstallMethod( PreImagesRepresentativeNC,
     "for homomorphisms of free groups",
     FamRangeEqFamElm,
     [ IsToFpGroupGeneralMappingByImages, IsElementOfFreeGroup ],

--- a/tst/FGA.tst
+++ b/tst/FGA.tst
@@ -19,7 +19,7 @@ gap> RepresentativeAction(g,f.2*f.1,f.1*f.2);
 f1^-1*f2^-1*f1^-1
 gap> RepresentativeAction(Group(f.1*f.2),f.1*f.2,f.2*f.1);
 fail
-gap> # bug reportet by Ignat Soroko, example slightly modified
+gap> # bug reported by Ignat Soroko, example slightly modified
 gap> a:=f.1;; b:=f.2;;
 gap> g := Group( a^b, a^(b^-1), b^4 );;
 gap> h := Group( b^2, a^b, a*b*a );;
@@ -69,4 +69,23 @@ gap> homFree:=GroupHomomorphismByImages(F, F, [], []);
 [  ] -> [  ]
 gap> PreImagesRepresentative(homFree, One(F));
 <identity ...>
+gap> # Manual example from section 2.3
+gap> ua := f.1^2*f.2^2;; ub := f.1^2*f.2;;
+gap> u := Group( ua, ub );;
+gap> g := FreeGroup( "a", "b" );;
+gap> hom := GroupHomomorphismByImages( g, u,
+>             GeneratorsOfGroup(g),
+>             GeneratorsOfGroup(u) );
+[ a, b ] -> [ f1^2*f2^2, f1^2*f2 ]
+gap> # how can f.1^2 be expressed?
+gap> PreImagesRepresentativeNC( hom, f.1^2 );
+b*a^-1*b
+gap> last ^ hom; # check this
+f1^2
+gap> ub * ua^-1 * ub; # another check
+f1^2
+gap> PreImagesRepresentativeNC( hom, f.1 ); # try f.1
+fail
+gap> f.1 in u;
+false
 gap> STOP_TEST( "FGA.tst", 100000);


### PR DESCRIPTION
PreImagesRepresentative, PreImages, PreImagesSet and PreImagesElm can all return incorrect results when the element(s) supplied are not in the range of the map.
This situation has been discussed in GAP issue #4809.
To rectify the situation the plan is to have NC versions of these four operations and to add tests to the non-NC versions.
The procedure to be adopted is as follows.
(1) Rename the four operations by adding 'NC' to their names, and then declare the original operations as synonyms of these. PR #5073 addresses this.
(2) Ask package authors/maintainers to convert all their calls to these functions to the NC versions (unless there is good reason not to do so).
A clause added to init.g ensures the package works in older versions of GAP.
(3) Once all the packages have been updated, add tests to the non-NC versions of the operations.

No progress has been made on this since February, but now seems a good time to continue with stage (2).  This PR attempts to implement (2) for package FGA which only uses the first of these 4 operations.                 
Apart from the one new method in Hom.gi, which this PR changes to the NC version, there are just two calls in the tests (and the manual, section 2.3), but no obvious need to change these. 
I suspect, for FGA, it is probably best to ignore this PR and keep to the status quo. 